### PR TITLE
Temporarily hide Blog section from homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
         <a href="#bio">Bio</a>
         <a href="#news">News</a>
         <a href="#publications">Publications</a>
-        <a href="#blog">Blog</a>
+        <!-- <a href="#blog">Blog</a> temporarily hidden -->
         <a href="#honors">Honors</a>
         <a href="#misc">Misc</a>
       </nav>
@@ -365,6 +365,8 @@
       </div>
     </section>
 
+    <!-- Blog section temporarily hidden; egoant report remains at /egoant-wgo-report/ -->
+    <!--
     <section id="blog" class="section" aria-labelledby="blog-title">
       <div class="wrap">
         <p class="section-kicker">Writing</p>
@@ -376,6 +378,7 @@
         </a>
       </div>
     </section>
+    -->
 
     <section id="honors" class="section" aria-labelledby="honors-title">
       <div class="wrap">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Hide the **Blog** navigation link on the homepage
- Comment out the Blog section so it no longer appears on the main page
- The EgoANT report remains fully accessible at `/egoant-wgo-report/` via direct URL

## Notes

This is a temporary change. To restore the Blog section later, uncomment the nav link and section in `index.html`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa2f4-2912-7f00-9f87-9f5f9ca0b018"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa2f4-2912-7f00-9f87-9f5f9ca0b018"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

