### PR TITLE
Add AGENTS.md with Cursor Cloud dev setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repository is a **static site** (HTML/CSS/vanilla JS) with **no build step, no package manager, and no dependencies to install**. Python 3 is the only runtime requirement (used purely for local static file servers) and is preinstalled in the Cloud environment.
+
+There are two independent static "products", each served on its own port:
+
+- **Personal homepage** (repo root): `index.html`, `stylesheet.css`, `images/`, `documents/`.
+  - Run: `python3 -m http.server 8080` from the repo root, then open `http://localhost:8080/`.
+- **EgoANT × HomER research report** (`egoant-wgo-report/`): interactive bilingual (ZH/EN) report.
+  - Run: `python3 serve_report.py --port 8765` from inside `egoant-wgo-report/` (see `egoant-wgo-report/README.md`), then open `http://localhost:8765/`.
+
+Non-obvious caveats:
+
+- The report **must** be served over HTTP, not opened as a `file://` path: it uses `fetch()` to load `data/*.json` (blocked under `file://`, which shows a "Could not load data files" banner) and needs HTTP **Range** support for HTML5 video seeking. Use `serve_report.py` (Range-enabled); plain `python3 -m http.server` does not serve Range requests. `egoant-wgo-report/serve.py` is an equivalent alternative.
+- There are no lint or automated-test suites in this repo. "Testing" means serving the site and visually verifying it in a browser.
+- The GitHub Pages deploy workflow (`.github/workflows/deploy.yaml`) is intentionally disabled (`if: false`); the other workflows are Hugo Blox template leftovers and do not affect the site.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Sets up and documents the development environment for this repository. This is a static site (HTML/CSS/vanilla JS) with **no build step and no dependencies to install** — Python 3 is the only runtime, used for local static file servers.

Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section capturing durable, non-obvious run caveats for future agents.

## Services

The repo ships two independent static products, each served on its own port:

| Product | Run command | URL |
|---|---|---|
| Personal homepage (repo root) | `python3 -m http.server 8080` | http://localhost:8080/ |
| EgoANT × HomER report (`egoant-wgo-report/`) | `python3 serve_report.py --port 8765` | http://localhost:8765/ |

Key caveat documented: the report must be served over HTTP (not `file://`) and requires an HTTP Range-capable server (`serve_report.py`) for JSON `fetch()` and HTML5 video seeking.

## Verification

Both sites were run and tested end-to-end in a browser:
- Homepage renders bio, news, blogs, and publications with video teasers.
- EgoANT report loads all `data/*.json` with no error banner, plays the hero video grid, shows the metrics table, and the ZH/EN language toggle works.

[homepage_and_egoant_report_e2e.mp4](https://cursor.com/agents/bc-86f3818a-dc7d-48ec-bae0-944f12fa4d27/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_and_egoant_report_e2e.mp4)

[Homepage top](https://cursor.com/agents/bc-86f3818a-dc7d-48ec-bae0-944f12fa4d27/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_top.webp)
[EgoANT report (ZH)](https://cursor.com/agents/bc-86f3818a-dc7d-48ec-bae0-944f12fa4d27/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fegoant_report_zh.webp)
[EgoANT report (EN after toggle)](https://cursor.com/agents/bc-86f3818a-dc7d-48ec-bae0-944f12fa4d27/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fegoant_report_en_toggle.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-86f3818a-dc7d-48ec-bae0-944f12fa4d27?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86f3818a-dc7d-48ec-bae0-944f12fa4d27&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

